### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Edit the list below and submit a pull request.  Add to the appropriate category 
 
 * Case Western Reserve
 * Comcast
-* Electicity \*
+* Electricity \*
 * Jeff's Keyboard \*
 * Netflix
 * Oxygen \*


### PR DESCRIPTION
I assumed that `Electicity` is not a new cool fancy type of energy, but just a typo. Sorry if I was mistaken.