### PR TITLE
hide inline copy buttons for unmatched serach results

### DIFF
--- a/src/style/_search-results.scss
+++ b/src/style/_search-results.scss
@@ -15,6 +15,10 @@
   padding-left: 0;
   list-style: none;
 
+  .inline-copy {
+    display: block;
+  }
+
   li {
     position: relative;
     @include transition(all 0.5s ease-in-out);
@@ -25,11 +29,11 @@
     &.not-match {
       margin-bottom: 0;
       height: 0;
-    }
-  }
 
-  .inline-copy {
-    display: block;
+      .inline-copy {
+        height: 0;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
When a search is performed, the inline copy buttons of the unmatched elements are not hidden.
![image](https://cloud.githubusercontent.com/assets/576772/24209395/68b13fc4-0f26-11e7-8b6c-faf44fff237e.png)

I added a CSS rule so that `.search-list li.not-match .inline-copy` has a `height` of `0` that will be animated along with the other properties impacted by the `@include transition` rule just above.

![image](https://cloud.githubusercontent.com/assets/576772/24209411/7406ca1a-0f26-11e7-9efa-5cb36a421151.png)
