### PR TITLE
Static version of "build: passing" CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![forthebadge](https://forthebadge.com/images/badges/fuck-it-ship-it.svg)](https://forthebadge.com)
 [![forthebadge](https://forthebadge.com/images/badges/no-ragrets.svg)](https://forthebadge.com)
 
-We don't develop for the money, power, fame, or codebabes. We do it **For the Badge.** It all started because of an obsession with two words: ![Build Status](https://img.shields.io/badge/build-passing-success). It all ended with this: _badges, for badges’ sake_.
+We don't develop for the money, power, fame, or codebabes. We do it **For the Badge.** It all started because of an obsession with two words: ![Build Passing](https://img.shields.io/badge/build-passing-success). It all ended with this: _badges, for badges’ sake_.
 
 ## Badge Usage
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-﻿# For the Badge
+# For the Badge
 
 [![forthebadge](https://forthebadge.com/images/badges/fuck-it-ship-it.svg)](https://forthebadge.com)
 [![forthebadge](https://forthebadge.com/images/badges/no-ragrets.svg)](https://forthebadge.com)
 
-We don't develop for the money, power, fame, or codebabes. We do it **For the Badge.** It all started because of an obsession with two words: [![Build Status](https://travis-ci.org/BraveUX/for-the-badge.svg)](https://travis-ci.org/BraveUX/for-the-badge). It all ended with this: _badges, for badges’ sake_.
+We don't develop for the money, power, fame, or codebabes. We do it **For the Badge.** It all started because of an obsession with two words: ![Build Status](https://img.shields.io/badge/build-passing-success). It all ended with this: _badges, for badges’ sake_.
 
 ## Badge Usage
 


### PR DESCRIPTION
The Travis CI badge shows `build: error`. I think those two words weren't what you were obsessed with ;)
I replaced it with a static one from [shields.io](//shields.io).